### PR TITLE
Naviatolin/parta step1

### DIFF
--- a/part_a/tasksys.cpp
+++ b/part_a/tasksys.cpp
@@ -1,5 +1,11 @@
 #include "tasksys.h"
 
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+#include <stdio.h>
+
 
 IRunnable::~IRunnable() {}
 
@@ -45,30 +51,57 @@ void TaskSystemSerial::sync() {
 const char* TaskSystemParallelSpawn::name() {
     return "Parallel + Always Spawn";
 }
-
-TaskSystemParallelSpawn::TaskSystemParallelSpawn(int num_threads): ITaskSystem(num_threads) {
-    //
-    // TODO: CS149 student implementations may decide to perform setup
-    // operations (such as thread pool construction) here.
-    // Implementations are free to add new class member variables
-    // (requiring changes to tasksys.h).
-    //
+im
+// Just only added the thread_total_num variable
+// I don't know c++ that well so I am wondering if I can
+// just access num_threads without this assignment.
+TaskSystemParallelSpawn::TaskSystemParallelSpawn(int num_threads)
+    : ITaskSystem(num_threads){
+    thread_total_num = num_threads;
 }
 
 TaskSystemParallelSpawn::~TaskSystemParallelSpawn() {}
 
-void TaskSystemParallelSpawn::run(IRunnable* runnable, int num_total_tasks) {
-
-
-    //
-    // TODO: CS149 students will modify the implementation of this
-    // method in Part A.  The implementation provided below runs all
-    // tasks sequentially on the calling thread.
-    //
-
-    for (int i = 0; i < num_total_tasks; i++) {
-        runnable->runTask(i, num_total_tasks);
+void runTaskSystemParallel(IRunnable* runnable, int num_total_tasks, int* counter, std::mutex* mutex){
+    for (;;) {
+        // find the current integer stored in a mutex
+        mutex->lock();
+        // if there are still tasks to be done, continue
+        if (*counter < num_total_tasks) {
+            *counter += 1;
+            mutex->unlock();
+            runnable->runTask(*counter, num_total_tasks);
+        }
+        // otherwise, exit the loop
+        else {
+            mutex->unlock();
+            break;
+        }
     }
+}
+
+void TaskSystemParallelSpawn::run(IRunnable* runnable, int num_total_tasks) {
+    // Create threads and a mutex
+    std::thread* threads = new std::thread[thread_total_num];
+    std::mutex* mutex = new std::mutex;
+
+    // initialize the counter
+    int counter = 0;
+
+    // start the threads
+    for (int i = 0; i < thread_total_num; i++) {
+        threads[i] = std::thread(runTaskSystemParallel, runnable, 
+            num_total_tasks, &counter, mutex);
+    }
+
+    // wait for the threads to join
+    for (int i = 0; i < thread_total_num; i++) {
+        threads[i].join();
+    }
+
+    // delete the mutex and threads as shown in the tutorial
+    delete mutex;
+    delete[] threads;
 }
 
 TaskID TaskSystemParallelSpawn::runAsyncWithDeps(IRunnable* runnable, int num_total_tasks,

--- a/part_a/tasksys.h
+++ b/part_a/tasksys.h
@@ -1,6 +1,12 @@
 #ifndef _TASKSYS_H
 #define _TASKSYS_H
 
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+#include <stdio.h>
+
 #include "itasksys.h"
 
 /*
@@ -34,7 +40,11 @@ class TaskSystemParallelSpawn: public ITaskSystem {
         TaskID runAsyncWithDeps(IRunnable* runnable, int num_total_tasks,
                                 const std::vector<TaskID>& deps);
         void sync();
+    private:
         int thread_total_num;
+        std::thread* workers;
+        std::mutex* mutex;
+        void dynamicTaskAssignment(IRunnable* runnable, int num_total_tasks, int *counter);
 };
 
 /*

--- a/part_a/tasksys.h
+++ b/part_a/tasksys.h
@@ -34,6 +34,7 @@ class TaskSystemParallelSpawn: public ITaskSystem {
         TaskID runAsyncWithDeps(IRunnable* runnable, int num_total_tasks,
                                 const std::vector<TaskID>& deps);
         void sync();
+        int thread_total_num;
 };
 
 /*


### PR DESCRIPTION
Finished and tested Part a implementation.

The following are our test results for this section.

```================================================================================
Running task system grading harness... (11 total tests)
  - Detected CPU with 10 execution contexts
  - Task system configured to use at most 8 threads
================================================================================
================================================================================
Executing test: super_super_light...
Reference binary: ./runtasks_ref_osx_arm
Results for: super_super_light
                                        STUDENT   REFERENCE   PERF?
[Serial]                                5.564     5.273       1.06  (OK)
[Parallel + Always Spawn]               80.225    76.33       1.05  (OK)
[Parallel + Thread Pool + Spin]         5.947     189.69      0.03  (OK)
[Parallel + Thread Pool + Sleep]        5.551     44.394      0.13  (OK)
================================================================================
Executing test: super_light...
Reference binary: ./runtasks_ref_osx_arm
Results for: super_light
                                        STUDENT   REFERENCE   PERF?
[Serial]                                27.934    42.167      0.66  (OK)
[Parallel + Always Spawn]               96.033    90.536      1.06  (OK)
[Parallel + Thread Pool + Spin]         27.625    288.357     0.10  (OK)
[Parallel + Thread Pool + Sleep]        30.127    64.176      0.47  (OK)
================================================================================
Executing test: ping_pong_equal...
Reference binary: ./runtasks_ref_osx_arm
Results for: ping_pong_equal
                                        STUDENT   REFERENCE   PERF?
[Serial]                                490.189   680.361     0.72  (OK)
[Parallel + Always Spawn]               234.232   303.056     0.77  (OK)
[Parallel + Thread Pool + Spin]         488.42    485.892     1.01  (OK)
[Parallel + Thread Pool + Sleep]        488.397   261.723     1.87  (NOT OK)
================================================================================
Executing test: ping_pong_unequal...
Reference binary: ./runtasks_ref_osx_arm
Results for: ping_pong_unequal
                                        STUDENT   REFERENCE   PERF?
[Serial]                                1281.36   1003.557    1.28  (NOT OK)
[Parallel + Always Spawn]               472.039   765.706     0.62  (OK)
[Parallel + Thread Pool + Spin]         1288.433  1751.388    0.74  (OK)
[Parallel + Thread Pool + Sleep]        1281.804  722.461     1.77  (NOT OK)
================================================================================
Executing test: recursive_fibonacci...
Reference binary: ./runtasks_ref_osx_arm
Results for: recursive_fibonacci
                                        STUDENT   REFERENCE   PERF?
[Serial]                                2301.021  2325.573    0.99  (OK)
[Parallel + Always Spawn]               1036.241  943.417     1.10  (OK)
[Parallel + Thread Pool + Spin]         2303.562  1174.67     1.96  (NOT OK)
[Parallel + Thread Pool + Sleep]        2319.958  981.448     2.36  (NOT OK)
================================================================================
Executing test: math_operations_in_tight_for_loop...
Reference binary: ./runtasks_ref_osx_arm
Results for: math_operations_in_tight_for_loop
                                        STUDENT   REFERENCE   PERF?
[Serial]                                425.276   423.22      1.00  (OK)
[Parallel + Always Spawn]               1215.537  1197.952    1.01  (OK)
[Parallel + Thread Pool + Spin]         424.112   5056.283    0.08  (OK)
[Parallel + Thread Pool + Sleep]        425.115   963.629     0.44  (OK)
================================================================================
Executing test: math_operations_in_tight_for_loop_fewer_tasks...
Reference binary: ./runtasks_ref_osx_arm
Results for: math_operations_in_tight_for_loop_fewer_tasks
                                        STUDENT   REFERENCE   PERF?
[Serial]                                412.968   425.07      0.97  (OK)
[Parallel + Always Spawn]               1204.795  1205.047    1.00  (OK)
[Parallel + Thread Pool + Spin]         419.35    4842.148    0.09  (OK)
[Parallel + Thread Pool + Sleep]        413.991   966.646     0.43  (OK)
================================================================================
Executing test: math_operations_in_tight_for_loop_fan_in...
Reference binary: ./runtasks_ref_osx_arm
Results for: math_operations_in_tight_for_loop_fan_in
                                        STUDENT   REFERENCE   PERF?
[Serial]                                218.841   211.273     1.04  (OK)
[Parallel + Always Spawn]               256.895   239.34      1.07  (OK)
[Parallel + Thread Pool + Spin]         216.132   800.618     0.27  (OK)
[Parallel + Thread Pool + Sleep]        217.449   217.843     1.00  (OK)
================================================================================
Executing test: math_operations_in_tight_for_loop_reduction_tree...
Reference binary: ./runtasks_ref_osx_arm
Results for: math_operations_in_tight_for_loop_reduction_tree
                                        STUDENT   REFERENCE   PERF?
[Serial]                                218.586   219.219     1.00  (OK)
[Parallel + Always Spawn]               116.622   139.27      0.84  (OK)
[Parallel + Thread Pool + Spin]         219.547   229.268     0.96  (OK)
[Parallel + Thread Pool + Sleep]        217.49    123.402     1.76  (NOT OK)
================================================================================
Executing test: spin_between_run_calls...
Reference binary: ./runtasks_ref_osx_arm
Results for: spin_between_run_calls
                                        STUDENT   REFERENCE   PERF?
[Serial]                                827.053   815.985     1.01  (OK)
[Parallel + Always Spawn]               481.748   469.919     1.03  (OK)
[Parallel + Thread Pool + Spin]         824.568   690.781     1.19  (OK)
[Parallel + Thread Pool + Sleep]        815.997   478.88      1.70  (NOT OK)
================================================================================
Executing test: mandelbrot_chunked...
Reference binary: ./runtasks_ref_osx_arm
Results for: mandelbrot_chunked
                                        STUDENT   REFERENCE   PERF?
[Serial]                                561.274   558.321     1.01  (OK)
[Parallel + Always Spawn]               205.789   223.134     0.92  (OK)
[Parallel + Thread Pool + Spin]         554.751   255.833     2.17  (NOT OK)
[Parallel + Thread Pool + Sleep]        558.806   193.691     2.89  (NOT OK)
================================================================================
Overall performance results
[Serial]                                : Perf did not pass all tests
[Parallel + Always Spawn]               : All passed Perf
[Parallel + Thread Pool + Spin]         : Perf did not pass all tests
[Parallel + Thread Pool + Sleep]        : Perf did not pass all tests```